### PR TITLE
Handle package name mismatch

### DIFF
--- a/cueimports.go
+++ b/cueimports.go
@@ -325,6 +325,8 @@ func resolveInPackage(unresolved map[string][]string, resolved map[string]string
 							rel = strings.TrimPrefix(rel, "cue.mod/pkg/")
 							rel = strings.TrimPrefix(rel, "cue.mod/usr/")
 							resolved[pkgName] = rel
+						} else if rel != pkgName {
+							resolved[pkgName] = filepath.Join(modName, rel) + ":" + pkgName
 						} else {
 							resolved[pkgName] = filepath.Join(modName, rel)
 						}

--- a/testdata/dimensions/alt.cue
+++ b/testdata/dimensions/alt.cue
@@ -1,0 +1,6 @@
+package alt
+
+#AltDimensions: {
+	w: int
+	h: int
+}

--- a/testdata/file.cue
+++ b/testdata/file.cue
@@ -6,6 +6,10 @@ wall: {
 		w: 100
 		h: 100
 	}
+	altSize: alt.#AltDimensions & {
+		w: 150
+		h: 150
+	}
 	priceM2: math.Floor(w * h / 10000)
 }
 

--- a/testdata/file.cue.golden
+++ b/testdata/file.cue.golden
@@ -6,6 +6,7 @@ import (
 	
 	"colors"
 	"test.com/dimensions"
+	"test.com/dimensions:alt"
 )
 
 wall: {
@@ -13,6 +14,10 @@ wall: {
 	size:  dimensions.#Dimensions & {
 		w: 100
 		h: 100
+	}
+	altSize: alt.#AltDimensions & {
+		w: 150
+		h: 150
 	}
 	priceM2: math.Floor(w * h / 10000)
 }


### PR DESCRIPTION
Support the scenario where the name of the package does not match that of its parent directory.

Resolves #1